### PR TITLE
Fix usage printing of flash string

### DIFF
--- a/SIGNALESP/output.h
+++ b/SIGNALESP/output.h
@@ -2,6 +2,8 @@
 #ifndef _OUTPUT_h
 #define _OUTPUT_h
 
+//for ESP8266 __FlashStringHelper*
+#include <WString.h>
 
 
 #ifdef CMP_CC1101
@@ -21,7 +23,8 @@ static const char TXT_FOUND[]				PROGMEM = "found ";
 static const char TXT_COMMAND[]				PROGMEM = "command e";
 static const char TXT_DOFRESET[]			PROGMEM = "is not correctly set. Please do a factory reset via ";
 static const char TXT_CCREVISION[]			PROGMEM = "CCVersion =";
-static const char TXT_UNSUPPORTED1[]		PROGMEM = "Unsupported short command";
+//just fix this one command for now
+static const __FlashStringHelper* TXT_UNSUPPORTED1 = FPSTR("Unsupported short command");
 static const char TXT_MU[]					PROGMEM = "MU";
 static const char TXT_MC[]					PROGMEM = "MC";
 static const char TXT_MS[]					PROGMEM = "MS";


### PR DESCRIPTION
The base problem is that code like

```cpp
		default:
			Serial.println("unsported short");
			MSG_PRINTLN(TXT_UNSUPPORTED1);
			return;
```

with `MSG_PRINTLN()` 

```cpp
#define MSG_PRINTLN(...) { MSG_PRINTER.println(__VA_ARGS__); }
```

And `TXT_UNSUPPORTED1`:

```
static const char TXT_UNSUPPORTED1[]		PROGMEM = "Unsupported short command";
```

creates a `const char[]` that is being used for `println()`, which is however stored in flash. For the ESP8266, we have to **explicitly** say that this pointer points to FLASH and not RAM. Otherwise reading from this memory address in an unaligned way will crash. 

Thus the fix is to change the type of these constant strings to `__FlashStringHelper`, so that a different version of the `.println()` function is called which explicitily handles these strings stored in flash. 

```cpp
static const __FlashStringHelper* TXT_UNSUPPORTED1 = FPSTR("Unsupported short command");
```

Alternatively you can also drop the PROGRMEM keyword so that the strings are stored in RAM, but this has more memory usage.

The problem in the `serialEvent()` function is also that it doesn't properly detect `\r\n` lineending sequences sent by PuTTY. E.g., typing `V` and pressing enter will result in `V\r\n`. The program will read `V` and `\r` and execute the version command, and it will then read the `\n`, and try to execute that as a command. Since there is no such command it will attempt to print "Unsupported short command", which triggers the printing of a string located in flash with a function handling printing from RAM. Thus we get a crash.

Pre-fix output on the serial when entering "V" via PuTTY: 

```
New client:  
192.168.1.180 


Fatal exception 3(LoadStoreErrorCause):<\n>
epc1=0x4000e041, epc2=0x00000000, epc3=0x00000000, excvaddr=0x4024ca7a, depc=0x00000000<\n>
<\n>
Exception (3):<\n>
epc1=0x4000e041 epc2=0x00000000 epc3=0x00000000 excvaddr=0x4024ca7a depc=0x00000000<\n>
<\n>
>>>stack>>><\n>
<\n>
ctx: cont<\n>
sp: 3ffffce0 end: 3fffffc0 offset: 01a0<\n>
3ffffe80:  00000003 00000019 4024ca62 00000000  <\n>
3ffffe90:  00000001 3fff1f5c 00000000 000001ff  <\n>
3ffffea0:  00000000 00000019 4010040c 0004d209  <\n>
3ffffeb0:  00000000 000002ec 000002ec 4024ca62  <\n>
3ffffec0:  00000000 00000019 3fff16a4 4020f314  <\n>
3ffffed0:  00000001 00000000 00000020 4024ca62  <\n>
3ffffee0:  00000001 00000000 3fff16a4 4020f3ae  <\n>
3ffffef0:  00000019 00000000 3fff16a4 4020f489  <\n>
3fffff00:  40215b60 00000000 00001388 00000057  <\n>
3fffff10:  4020f44c 3ffef2b8 4024ca62 402115b1  <\n>
3fffff20:  3ffef170 3ffef170 3ffef2b8 4021189d  <\n>
3fffff30:  007a1200 3ffef170 3ffeef30 402019b9  <\n>
3fffff40:  00000000 00000000 00000001 40221c9e  <\n>
3fffff50:  3ffef170 00000000 3fff16a4 4020f53a  <\n>
3fffff60:  3ffef170 3ffef2b8 0000000d 3ffef177  <\n>
3fffff70:  3ffef170 3ffef2b8 3ffeef30 402027dd  <\n>
3fffff80:  3fffdad0 00000000 3ffef78c 3ffef7cc  <\n>
3fffff90:  3fffdad0 00000000 3ffef78c 40202849  <\n>
3fffffa0:  3fffdad0 00000000 3ffef78c 402138b4  <\n>
3fffffb0:  feefeffe feefeffe 3ffe8500 40101069  <\n>
<<<stack<<<<\n>

 ets Jan  8 2013,rst cause:2, boot mode:(3,6)<\r><\n>

```

now no crash and output via PuTTY:

```
V
V 3.4.0-dev SIGNALESP  - compiled at Feb  8 2020 18:05:39
Unsupported short command
```

And the firmware dosen't crash.